### PR TITLE
Support for regional indicators

### DIFF
--- a/spec/bytes_to_string_spec.js
+++ b/spec/bytes_to_string_spec.js
@@ -12,9 +12,14 @@ describe('UtfString', function() {
       expect(UtfString.bytesToString(arr)).toEqual('ありがとう')
     });
 
-    it('works when given start and end indices', function() {
+    it('works with unicode astral plane characters', function() {
       var arr = [216, 81, 221, 35, 216, 81, 221, 36, 216, 81, 221, 37, 216, 81, 221, 38];
       expect(UtfString.bytesToString(arr)).toEqual('𤔣𤔤𤔥𤔦');
+    });
+
+    it('works with pairs of regional indicators', function() {
+      var arr = [216, 60, 221, 235, 216, 60, 221, 247];
+      expect(UtfString.bytesToString(arr)).toEqual('🇫🇷');
     });
   });
 });

--- a/spec/char_at_spec.js
+++ b/spec/char_at_spec.js
@@ -26,6 +26,12 @@ describe('UtfString', function() {
       expect(UtfString.charAt(str, 3)).toEqual('𤔦');
     });
 
+    it('works with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+      expect(UtfString.charAt(str, 0)).toEqual('🇸🇴');
+      expect(UtfString.charAt(str, 1)).toEqual('🇫🇷');
+    });
+
     it('returns an empty string for indices that are out of range', function() {
       var str = 'abc';
       expect(UtfString.charAt(str, 3)).toEqual('');

--- a/spec/char_code_at_spec.js
+++ b/spec/char_code_at_spec.js
@@ -23,5 +23,11 @@ describe('UtfString', function() {
       expect(UtfString.charCodeAt(str, 0)).toEqual(148771);
       expect(UtfString.charCodeAt(str, 1)).toBeNaN();
     });
+
+    it('works with regional indicators', function() {
+      var str = '🇫🇷';
+      expect(UtfString.charCodeAt(str, 0)).toEqual(127467);
+      expect(UtfString.charCodeAt(str, 1)).toEqual(127479);
+    });
   });
 });

--- a/spec/code_points_to_string_spec.js
+++ b/spec/code_points_to_string_spec.js
@@ -9,12 +9,17 @@ describe('UtfString', function() {
 
     it('works with multi-byte characters', function() {
       var arr = [12354, 12426, 12364, 12392, 12358];
-      expect(UtfString.codePointsToString(arr)).toEqual('ありがとう')
+      expect(UtfString.codePointsToString(arr)).toEqual('ありがとう');
     });
 
-    it('works when given start and end indices', function() {
+    it('works with characters in the unicode astral plane', function() {
       var arr = [148771, 148772, 148773, 148774];
-      expect(UtfString.codePointsToString(arr)).toEqual('𤔣𤔤𤔥𤔦')
+      expect(UtfString.codePointsToString(arr)).toEqual('𤔣𤔤𤔥𤔦');
+    });
+
+    it('works with regional indicators', function() {
+      var arr = [127467, 127479];
+      expect(UtfString.codePointsToString(arr)).toEqual('🇫🇷');
     });
   });
 });

--- a/spec/from_char_code_spec.js
+++ b/spec/from_char_code_spec.js
@@ -19,5 +19,9 @@ describe('UtfString', function() {
     it('works with astral plane unicode characters', function() {
       expect(UtfString.fromCharCode(148771)).toEqual('𤔣');
     });
+
+    it('works with regional indicators', function() {
+      expect(UtfString.fromCharCode(127467)).toEqual('🇫');
+    });
   });
 });

--- a/spec/index_of_spec.js
+++ b/spec/index_of_spec.js
@@ -34,6 +34,16 @@ describe('UtfString', function() {
       expect(UtfString.indexOf(str, '𤔦')).toEqual(3);
     });
 
+    it('works with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+      expect(UtfString.indexOf(str, '🇸🇴')).toEqual(0);
+      expect(UtfString.indexOf(str, '🇫🇷')).toEqual(1);
+      expect(UtfString.indexOf(str, '🇸')).toEqual(0);
+      expect(UtfString.indexOf(str, '🇴')).toEqual(0);
+      expect(UtfString.indexOf(str, '🇫')).toEqual(1);
+      expect(UtfString.indexOf(str, '🇷')).toEqual(1);
+    });
+
     it('works with mixed characters', function() {
       var str = 'あaりbがc𤔣dとeうf';
       expect(UtfString.indexOf(str, 'a')).toEqual(1);

--- a/spec/last_index_of_spec.js
+++ b/spec/last_index_of_spec.js
@@ -34,6 +34,14 @@ describe('UtfString', function() {
       expect(UtfString.lastIndexOf(str, '𤔦')).toEqual(3);
     });
 
+    it('works with regional indicators', function() {
+      var str = '🇫🇷🇸🇴🇫🇷';
+      expect(UtfString.lastIndexOf(str, '🇫🇷')).toEqual(2);
+      expect(UtfString.lastIndexOf(str, '🇫')).toEqual(2);
+      expect(UtfString.lastIndexOf(str, '🇷')).toEqual(2);
+      expect(UtfString.lastIndexOf(str, '🇸🇴')).toEqual(1);
+    });
+
     it('works with mixed characters', function() {
       var str = 'あaりbがc𤔣dとeうf';
       expect(UtfString.lastIndexOf(str, 'a')).toEqual(1);

--- a/spec/length_spec.js
+++ b/spec/length_spec.js
@@ -27,8 +27,26 @@ describe('UtfString', function() {
     });
 
     it('counts the number of characters in a mixed string', function() {
-      var str = 'あaりbがc𤔣dとeうf'
-      expect(UtfString.length(str)).toEqual(12);
+      var str = 'あaりbがc𤔣dとeうf🇫🇷g'
+      expect(UtfString.length(str)).toEqual(14);
+    });
+
+    it('correctly counts single regional indicator characters', function() {
+      var str = '🇸'
+      expect(str.length).toEqual(2);
+      expect(UtfString.length(str)).toEqual(1);
+    });
+
+    it('correctly counts pairs of regional indicator characters', function() {
+      var str = '🇸🇴'
+      expect(str.length).toEqual(4);
+      expect(UtfString.length(str)).toEqual(1);
+    });
+
+    it('correctly counts multiple pairs of regional indicator characters', function() {
+      var str = '🇸🇴🇫🇷'
+      expect(str.length).toEqual(8);
+      expect(UtfString.length(str)).toEqual(2);
     });
 
     it('returns zero when the string is empty', function() {

--- a/spec/slice_spec.js
+++ b/spec/slice_spec.js
@@ -79,5 +79,24 @@ describe('UtfString', function() {
         expect(UtfString.slice(str, 4, 5)).toEqual('');
       });
     });
+
+    describe('with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+
+      it('works when given start and end indices', function() {
+        expect(UtfString.slice(str, 0, 1)).toEqual('🇸🇴');
+        expect(UtfString.slice(str, 1, 2)).toEqual('🇫🇷');
+      });
+
+      it('works when not given an end index', function() {
+        expect(UtfString.slice(str, 0)).toEqual('🇸🇴🇫🇷');
+        expect(UtfString.slice(str, 1)).toEqual('🇫🇷');
+      });
+
+      it('returns an empty string when given out-of-bounds indices', function() {
+        expect(UtfString.slice(str, 4)).toEqual('');
+        expect(UtfString.slice(str, 4, 5)).toEqual('');
+      });
+    });
   });
 });

--- a/spec/string_to_bytes_spec.js
+++ b/spec/string_to_bytes_spec.js
@@ -16,7 +16,14 @@ describe('UtfString', function() {
       );
     });
 
-    it('works when given start and end indices', function() {
+    it('works with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+      expect(UtfString.stringToBytes(str)).toEqual(
+        [216, 60, 221, 248, 216, 60, 221, 244, 216, 60, 221, 235, 216, 60, 221, 247]
+      );
+    });
+
+    it('works with unicode astral plane characters', function() {
       var str = '𤔣𤔤𤔥𤔦';
       expect(UtfString.stringToBytes(str)).toEqual(
         [216, 81, 221, 35, 216, 81, 221, 36, 216, 81, 221, 37, 216, 81, 221, 38]

--- a/spec/string_to_char_array_spec.js
+++ b/spec/string_to_char_array_spec.js
@@ -1,0 +1,29 @@
+var UtfString = require('../utfstring.js').UtfString;
+
+describe('UtfString', function() {
+  describe('#stringToCharArray', function() {
+    it('works with standard ASCII characters', function() {
+      var str = 'abc';
+      expect(UtfString.stringToCharArray(str)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('works with multi-byte characters', function() {
+      var str = 'ありがとう';
+      expect(UtfString.stringToCharArray(str)).toEqual(
+        ['あ', 'り', 'が', 'と', 'う']
+      );
+    });
+
+    it('works with unicode astral plane characters', function() {
+      var str = '𤔣𤔤𤔥𤔦';
+      expect(UtfString.stringToCharArray(str)).toEqual(
+        ['𤔣', '𤔤', '𤔥', '𤔦']
+      );
+    });
+
+    it('works with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+      expect(UtfString.stringToCharArray(str)).toEqual(['🇸🇴', '🇫🇷']);
+    });
+  });
+});

--- a/spec/string_to_code_points_spec.js
+++ b/spec/string_to_code_points_spec.js
@@ -11,14 +11,19 @@ describe('UtfString', function() {
       var str = 'ありがとう';
       expect(UtfString.stringToCodePoints(str)).toEqual(
         [12354, 12426, 12364, 12392, 12358]
-      )
+      );
     });
 
-    it('works when given start and end indices', function() {
+    it('works with unicode astral plane characters', function() {
       var str = '𤔣𤔤𤔥𤔦';
       expect(UtfString.stringToCodePoints(str)).toEqual(
         [148771, 148772, 148773, 148774]
-      )
+      );
+    });
+
+    it('works with regional indicators', function() {
+      var str = '🇫🇷';
+      expect(UtfString.stringToCodePoints(str)).toEqual([127467, 127479]);
     });
   });
 });

--- a/spec/substr_spec.js
+++ b/spec/substr_spec.js
@@ -112,5 +112,36 @@ describe('UtfString', function() {
         expect(UtfString.substr(str, -5, 1)).toEqual('');
       });
     });
+
+    describe('with regional indicators', function() {
+      var str = '🇸🇴🇫🇷';
+
+      it('works when given a start and a length', function() {
+        expect(UtfString.substr(str, 0, 1)).toEqual('🇸🇴');
+        expect(UtfString.substr(str, 1, 1)).toEqual('🇫🇷');
+      });
+
+      it('works when not given a length', function() {
+        expect(UtfString.substr(str, 0)).toEqual('🇸🇴🇫🇷');
+        expect(UtfString.substr(str, 1)).toEqual('🇫🇷');
+      });
+
+      it('returns an empty string if given an out-of-bounds start', function() {
+        expect(UtfString.substr(str, 4, 1)).toEqual('');
+      });
+
+      it('returns up to the length of the string if given an out-of-bounds length', function() {
+        expect(UtfString.substr(str, 1, 10)).toEqual('🇫🇷');
+      });
+
+      it('accepts a negative start value', function() {
+        expect(UtfString.substr(str, -1, 1)).toEqual('🇫🇷');
+        expect(UtfString.substr(str, -2, 1)).toEqual('🇸🇴');
+      });
+
+      it('returns an empty string if the negative start value is out-of-bounds', function() {
+        expect(UtfString.substr(str, -3, 1)).toEqual('');
+      });
+    });
   });
 });

--- a/utfstring.js
+++ b/utfstring.js
@@ -182,6 +182,24 @@
       return result.join('');
     },
 
+    stringToCharArray: function(string) {
+      var result = [];
+      var regStr = unsupportedPairs.source + '|.';
+      var scanner = new RegExp(regStr, 'g');
+
+      do {
+        var match = scanner.exec(string);
+
+        if (match === null) {
+          break;
+        }
+
+        result.push(match[0]);
+      } while(match !== null);
+
+      return result;
+    },
+
     _findCharIndex: function(string, byteIndex) {
       // optimization: don't iterate unless necessary
       if (!this._containsUnsupportedCharacters(string)) {
@@ -192,7 +210,7 @@
       var scanner = new RegExp(regStr, 'g');
       var charCount = 0;
 
-      while (scanner.exec(string) != null) {
+      while (scanner.exec(string) !== null) {
         if (scanner.lastIndex > byteIndex) {
           break;
         }


### PR DESCRIPTION
Unicode defines certain "regional indicator" characters in the range 1F1E6-1F1FF that are supposed to be used in pairs but treated as individual logical characters. For example, the characters 1F1EB (F) and 1F1F7 (R) together represent the French flag: 🇫🇷

Unfortunately since 1F1EB and 1F1F7 are themselves codepoints, special logic must be added to UtfString to correctly treat them as individual characters.

 This PR also adds the `stringToCharArray` function.

cc @maddrag0n