### PR TITLE
Add pre-publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "scripts": {
         "format": "prettier --check .",
         "build": "rimraf dist browser && tsc && webpack",
-        "test": "mocha -r ts-node/register -reporter min 'test/**/*.ts'"
+        "test": "mocha -r ts-node/register -reporter min 'test/**/*.ts'",
+        "prepublishOnly": "npm test && npm run build"
     }
 }


### PR DESCRIPTION
Add a new script for npm's [prepublishOnly event](https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-publish) that runs the tests and the build before publishing the package. If any test or the build fails the publishing is aborted.

This should prevent the problem described in #13 from happening again.