### PR TITLE
Add start parameter to includes method

### DIFF
--- a/src/utf_string.ts
+++ b/src/utf_string.ts
@@ -151,10 +151,11 @@ export class UtfString {
     /**
      * Checks if the search value is within the string.
      * @param searchValue The value to search.
+     * @param start Optional start offset for the search.
      * @returns True if the search value was found in the string, false otherwise.
      */
-    public includes(searchValue: string | UtfString): boolean {
-        return this.indexOf(searchValue) !== -1;
+    public includes(searchValue: string | UtfString, start = 0): boolean {
+        return this.indexOf(searchValue, start) !== -1;
     }
 
     /**

--- a/test/unit/utf_string/non-static/includes_spec.ts
+++ b/test/unit/utf_string/non-static/includes_spec.ts
@@ -40,11 +40,36 @@ describe("UtfString", () => {
             expect(utfString.includes("d")).toBeFalsy();
         });
 
+        it("respects the start parameter", () => {
+            const utfString1 = new UtfString("abcabc");
+            expect(utfString1.includes("b", 0)).toBeTruthy();
+            expect(utfString1.includes("b", 2)).toBeTruthy();
+
+            const utfString2 = new UtfString("ありがとうり");
+            expect(utfString2.includes("り", 0)).toBeTruthy();
+            expect(utfString2.includes("り", 2)).toBeTruthy();
+
+            const utfString3 = new UtfString("𤔣𤔤𤔥𤔤𤔦");
+            expect(utfString3.includes("𤔤", 0)).toBeTruthy();
+            expect(utfString3.includes("𤔤", 2)).toBeTruthy();
+        });
+
         it("works with a UtfString parameter", () => {
             const utfString = new UtfString("abc");
             expect(utfString.includes(new UtfString("a"))).toBeTruthy();
             expect(utfString.includes(new UtfString("b"))).toBeTruthy();
             expect(utfString.includes(new UtfString("d"))).toBeFalsy();
+        });
+
+        it("returns false if the search value is not found after the given start parameter", () => {
+            const utfString1 = new UtfString("abc");
+            expect(utfString1.includes("b", 2)).toBeFalsy();
+
+            const utfString2 = new UtfString("ありが");
+            expect(utfString2.includes("り", 2)).toBeFalsy();
+
+            const utfString3 = new UtfString("𤔣𤔤𤔥");
+            expect(utfString3.includes("𤔤", 2)).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
Hi Cameron, looks like we forgot the second optional parameter when we added the string methods.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes