### PR TITLE
Simplify window detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 /// <reference lib="DOM" />
 import { UtfString } from "./utf_string";
 import { UtfVisualString } from "./utf_visual_string";
-import { isDefined } from "./utils";
 
 // if there is a global window object add the classes to it
-if (isDefined(window)) {
+if (typeof window !== 'undefined') {
     (window as any).UtfString = UtfString;
     (window as any).UtfVisualString = UtfVisualString;
 }


### PR DESCRIPTION
Hello. The current implementation of window detection works not well while running Jest tests with ts-node. It asks to enable jsdom test environment. With the proposed changes, the error is gone.